### PR TITLE
Allow query string parameters to be appended to request

### DIFF
--- a/src/Alba.Testing/Acceptance/assertions_against_the_querystring.cs
+++ b/src/Alba.Testing/Acceptance/assertions_against_the_querystring.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace Alba.Testing.Acceptance
+{
+    public class assertions_against_the_querystring : ScenarioContext
+    {
+        [Fact]
+        public Task using_scenario_with_QueryString_should_set_query_string_parameter()
+        {
+            host.Handlers["/one"] = c =>
+            {
+                c.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            };
+
+            return host.Scenario(_ =>
+            {
+                _.Get.QueryString("test", "value");
+
+                _.Context.Request.Query["test"].ToString().ShouldBe("value");
+            });
+        }
+    }
+}

--- a/src/Alba.Testing/Acceptance/specs_against_aspnet_core_app.cs
+++ b/src/Alba.Testing/Acceptance/specs_against_aspnet_core_app.cs
@@ -102,5 +102,16 @@ namespace Alba.Testing.Acceptance
             person.FirstName.ShouldBe("Peyton");
             person.LastName.ShouldBe("Manning");
         }
+
+
+        [Fact]
+        public Task can_send_querystring_parameters()
+        {
+            return run(_ =>
+            {
+                _.Get.QueryString("test", "value");
+                _.Get.Url("/query-string");
+            });
+        }
     }
 }

--- a/src/Alba.Testing/Acceptance/specs_against_aspnet_core_app.cs
+++ b/src/Alba.Testing/Acceptance/specs_against_aspnet_core_app.cs
@@ -113,5 +113,34 @@ namespace Alba.Testing.Acceptance
                 _.Get.Url("/query-string");
             });
         }
+
+        [Fact]
+        public Task returns_successfully_when_passed_input_is_passes_to_URL_query_string()
+        {
+            return run(_ =>
+            {
+                _.Get.Url("/query-string?test=value");
+            });
+        }
+
+        [Fact]
+        public Task returns_successfully_when_passed_string_is_passed_to_Input()
+        {
+            return run(_ =>
+            {
+                _.Get.Input("value");
+                _.Get.Url("/query-string");
+            });
+        }
+
+        [Fact]
+        public Task returns_successfully_when_passed_object_is_passed_to_Input()
+        {
+            return run(_ =>
+            {
+                _.Get.Input(new { test = "value"});
+                _.Get.Url("/query-string");
+            });
+        }
     }
 }

--- a/src/Alba/IUrlExpression.cs
+++ b/src/Alba/IUrlExpression.cs
@@ -72,5 +72,13 @@ namespace Alba
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         SendExpression FormData(Dictionary<string, string> input);
+
+        /// <summary>
+        /// Appends a query string paramater to the HttpRequest
+        /// </summary>
+        /// <param name="paramName"></param>
+        /// <param name="paramValue"></param>
+        /// <returns></returns>
+        SendExpression QueryString(string paramName, string paramValue);
     }
 }

--- a/src/Alba/Scenario.cs
+++ b/src/Alba/Scenario.cs
@@ -208,6 +208,13 @@ namespace Alba
         }
 
 
+        public SendExpression QueryString(string paramName, string paramValue)
+        {
+            Context.Request.QueryString = Context.Request.QueryString.Add(paramName, paramValue);
+            return new SendExpression(Context);
+        }
+
+
         public HeaderExpectations Header(string headerKey)
         {
             return new HeaderExpectations(this, headerKey);

--- a/src/WebApp/Controllers/QueryStringContoller.cs
+++ b/src/WebApp/Controllers/QueryStringContoller.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApp.Controllers
+{
+    public class QueryStringContoller : Controller
+    {
+        [HttpGet("query-string")]
+        public string QueryString([FromQuery] string test)
+        {
+            return test;
+        }
+    }
+}


### PR DESCRIPTION
I've been attempting to write tests against controller methods with query string parameters. I can safely hit those endpoints through something like Postman when the app is started, but I cannot hit them in any way that I could find using Alba.

Here's an example of failing tests:

### Invoking ``Input`` with a string - results in 204
```csharp
[Fact]
public Task returns_successfully_when_passed_input_as_query_string()
{
    return run(_ =>
    {
        _.Get.Input("value");
        _.Get.Url("/query-string");
    });
}
```

### Invoking ``Input`` with an object - results in 204
```csharp
[Fact]
public Task returns_successfully_when_passed_input_as_query_string()
{
    return run(_ =>
    {
        _.Get.Input(new { test = "value" });
        _.Get.Url("/query-string");
    });
}
```

### Invoking ``Url`` with the query string parameter appended - results in 404:

```csharp
[Fact]
public Task returns_successfully_when_passed_input_as_query_string()
{
    return run(_ =>
    {
        _.Get.Url("/query-string?test=value");
    });
}
```


This PR is an attempt to try and add the capability to append query string parameters to the request.

Here's an example of the usage that I've come up with.

```csharp
[Fact]
public Task can_send_querystring_parameters()
{
    return run(_ =>
    {
        _.Get.QueryString("test", "value");
        _.Get.Url("/query-string");
    });
}
```

However, I'm not sure why the code I've written doesn't work. It isn't setting any values in the QueryString collection at all and I don't know why.

Is this a use case worth solving for? it's possible to write tests that invoke the controller method directly.