### PR TITLE
Add scenario specific services

### DIFF
--- a/src/Alba.Testing/Acceptance/using_custom_service_for_single_scenario.cs
+++ b/src/Alba.Testing/Acceptance/using_custom_service_for_single_scenario.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using WebApp;
+using WebApp.Controllers;
+using Xunit;
+
+namespace Alba.Testing.Acceptance
+{
+    public class using_custom_service_for_single_scenario
+    {
+        [Fact]
+        public async Task system_should_maintain_dependency_graph_after_scenario_is_run()
+        {
+            using (var system = SystemUnderTest.ForStartup<Startup>())
+            {
+                await system.Scenario(_ =>
+                {
+                    _.ConfigureServices(s =>
+                    {
+                        s.AddTransient<ISimpleService, TestService>();
+                    });
+
+                    _.Get.Url("/test-service");
+                });
+
+                system.Services.GetService<ISimpleService>().ShouldBeOfType<SimpleService>();
+            }
+        }
+
+        [Fact]
+        public async Task replace_service_per_test()
+        {
+            using (var system = SystemUnderTest.ForStartup<Startup>())
+            {
+                var result = await system.Scenario(_ =>
+                {
+                    _.ConfigureServices(x =>
+                    {
+                        x.AddTransient<ISimpleService, TestService>();
+                    });
+
+                    _.Get.Url("/test-service");
+                });
+
+                result.ResponseBody.ReadAsText().ShouldBe("replaced");
+            }
+        }
+    }
+
+    public class TestService : ISimpleService
+    {
+        public string Test()
+        {
+            return "replaced";
+        }
+    }
+}

--- a/src/Alba/AlbaServiceProvider.cs
+++ b/src/Alba/AlbaServiceProvider.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Alba
+{
+    internal class AlbaServiceProvider : IServiceProvider, ISupportRequiredService
+    {
+        private readonly Stack<IServiceProvider> _serviceProviders = new Stack<IServiceProvider>();
+
+        public AlbaServiceProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProviders.Push(serviceProvider);
+        }
+
+        public object GetRequiredService(Type serviceType)
+        {
+            object service = null;
+            foreach (var serviceProvider in _serviceProviders)
+            {
+                try
+                {
+                    service = serviceProvider.GetRequiredService(serviceType);
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Could not resolve required service {serviceType.Name}");
+            }
+            return service;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            object service = null;
+            foreach (var serviceProvider in _serviceProviders)
+            {
+                try
+                {
+                    service = serviceProvider.GetService(serviceType);
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                }
+            }
+            if (service == null)
+            {
+                throw new InvalidOperationException($"Coiuld not resolve service {serviceType.Name}");
+            }
+            return service;
+        }
+
+        public void AddServices(IServiceCollection services)
+        {
+            _serviceProviders.Push(services.BuildServiceProvider());
+        }
+
+        public void Teardown()
+        {
+            while (_serviceProviders.Count >= 2)
+            {
+                _serviceProviders.Pop();
+            }
+        }
+    }
+}

--- a/src/Alba/SystemUnderTestExtensions.cs
+++ b/src/Alba/SystemUnderTestExtensions.cs
@@ -49,6 +49,7 @@ namespace Alba
                 }
                 finally
                 {
+                    scenario.Teardown();
                     await system.AfterEach(scenario.Context).ConfigureAwait(false);
                 }
 

--- a/src/WebApp/Controllers/ServiceController.cs
+++ b/src/WebApp/Controllers/ServiceController.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApp.Controllers
+{
+    public class ServiceController : Controller
+    {
+        private readonly ISimpleService _simpleService;
+
+        public ServiceController(ISimpleService simpleService)
+        {
+            _simpleService = simpleService;
+        }
+
+        [HttpGet("test-service")]
+        public string Get()
+        {
+            return _simpleService.Test();
+        }
+    }
+
+    public class SimpleService : ISimpleService
+    {
+        public string Test()
+        {
+            return "test";
+        }
+    }
+
+    public interface ISimpleService
+    {
+        string Test();
+    }
+}

--- a/src/WebApp/Startup.cs
+++ b/src/WebApp/Startup.cs
@@ -28,6 +28,7 @@ namespace WebApp
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddTransient<IWidget, GreenWidget>();
+            services.AddTransient<ISimpleService, SimpleService>();
 
             services.AddMvc(config =>
             {
@@ -35,7 +36,6 @@ namespace WebApp
                 config.InputFormatters.Clear();
                 config.InputFormatters.Add(new TextInputFormatter());
                 config.InputFormatters.Add(new JsonInputFormatter());
-                
             });
         }
 


### PR DESCRIPTION
The AblaServiceProvider allows multiple ServiceProviders to be configured
with their own individual ServiceCollections. When a service is requested,
it will loop through each ServiceProvider in the Stack and attempt to
resolve the dependency.

If there is no registered service in any of the ServiceProviders within
the AlbaServiceProvider, an InvalidOperationException is thrown indicating
that the service could not be resolved.

By introducing this class and wrapping the ServiceProvider within the
scenario with the AlbaServiceProvider, it allows services to be specified
for a specific scenario and only for that scenario. This adds the
flexibility to provide alternative implementations for tests.