### PR TITLE
Initial ASP.NET Core 2.0 support

### DIFF
--- a/src/Alba.sln
+++ b/src/Alba.sln
@@ -1,12 +1,14 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba", "Alba\Alba.csproj", "{81D9EFA5-F846-40F3-B36C-8E82111EDDF6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.Testing", "Alba.Testing\Alba.Testing.csproj", "{3CEBB819-9841-4353-B3A2-2331902E6228}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApp", "WebApp\WebApp.csproj", "{52733A25-1E8D-4250-A9B5-D135EE6C1557}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.AspNetCore2", "Alba\Alba.AspNetCore2.csproj", "{2788ACBD-012D-4541-8B92-15BE87D6291C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,8 +28,15 @@ Global
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2C4FAA2B-F991-4732-8D57-DFB1178440CA}
 	EndGlobalSection
 EndGlobal

--- a/src/Alba/Alba.AspNetCore2.csproj
+++ b/src/Alba/Alba.AspNetCore2.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Easy integration testing helper for ASP.Net Core applications</Description>
+    <AssemblyTitle>Alba</AssemblyTitle>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <AssemblyName>Alba.AspNetCore2</AssemblyName>
+    <PackageId>Alba.AspNetCore2</PackageId>
+    <PackageProjectUrl>http://jasperfx.github.io/alba/</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/JasperFx/alba/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/JasperFx/alba</RepositoryUrl>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Baseline" Version="1.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
+    <PackageReference Include="System.AppContext" Version="4.3.0" />
+    <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Alba/HeaderExtensions.cs
+++ b/src/Alba/HeaderExtensions.cs
@@ -17,7 +17,7 @@ namespace Alba
 
             if (rawValue.Count == 1 &&
                 !string.IsNullOrWhiteSpace(rawValue[0]) &&
-                HeaderUtilities.TryParseInt64(rawValue[0], out length))
+                TryParseInt64(rawValue[0], out length))
             {
                 return length;
             }
@@ -34,12 +34,27 @@ namespace Alba
         {
             if (value.HasValue)
             {
-                headers[HeaderNames.ContentLength] = HeaderUtilities.FormatInt64(value.Value);
+                headers[HeaderNames.ContentLength] = FormatInt64(value.Value);
             }
             else
             {
                 headers.Remove(HeaderNames.ContentLength);
             }
+        }
+
+        private static bool TryParseInt64(string input, out long value) {
+#if NETSTANDARD2_0
+            return HeaderUtilities.TryParseNonNegativeInt64(input, out value);
+#else
+            return HeaderUtilities.TryParseInt64(input, out value);
+#endif
+        }
+        private static string FormatInt64(long input) {
+#if NETSTANDARD2_0
+            return HeaderUtilities.FormatNonNegativeInt64(input);
+#else
+            return HeaderUtilities.FormatInt64(input);
+#endif
         }
     }
 }

--- a/src/Alba/Stubs/StubConnectionInfo.cs
+++ b/src/Alba/Stubs/StubConnectionInfo.cs
@@ -19,5 +19,9 @@ namespace Alba.Stubs
         public override IPAddress LocalIpAddress { get; set; }
         public override int LocalPort { get; set; }
         public override X509Certificate2 ClientCertificate { get; set; }
+
+#if NETSTANDARD2_0
+        public override string Id { get; set; }
+#endif
     }
 }

--- a/src/Alba/Stubs/StubSession.cs
+++ b/src/Alba/Stubs/StubSession.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
@@ -36,6 +37,18 @@ namespace Alba.Stubs
         {
             throw new NotImplementedException();
         }
+
+#if NETSTANDARD2_0
+        public Task LoadAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task CommitAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+#endif
 
         public bool IsAvailable { get; }
         public string Id { get; }

--- a/src/Alba/SystemUnderTestBase.cs
+++ b/src/Alba/SystemUnderTestBase.cs
@@ -24,7 +24,7 @@ namespace Alba
             _invoker = new Lazy<RequestDelegate>(() =>
             {
                 var host = _host.Value;
-                var field = typeof(WebHost).GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
+                var field = host.GetType().GetField("_application", BindingFlags.NonPublic | BindingFlags.Instance);
                 return field.GetValue(host).As<RequestDelegate>();
             });
 

--- a/src/Alba/TestServer.cs
+++ b/src/Alba/TestServer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
@@ -26,8 +27,28 @@ namespace Alba
 
         }
 
+#if NETSTANDARD2_0
+        public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
+        {
+            createApplicationWrapper(application);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _application = null;
+
+            return Task.CompletedTask;
+        }
+#else
         void IServer.Start<TContext>(IHttpApplication<TContext> application)
         {
+            createApplicationWrapper(application);
+        }
+#endif
+
+        private void createApplicationWrapper<TContext>(IHttpApplication<TContext> application) {
             _application = new ApplicationWrapper<Context>((IHttpApplication<Context>)application, () =>
             {
                 if (_disposed)


### PR DESCRIPTION
I've barely tested this, but it seems to work, and also looks like the only sane way to have packages for all combinations of tfm's and ASP.NET Core versions. Make of it what you will. 