### PR TITLE
Unit tests for Alba.AspNetCore2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
+++ b/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
@@ -14,6 +14,8 @@
     <RepositoryUrl>git://github.com/JasperFx/alba</RepositoryUrl>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <SourceRootFolder>../Alba</SourceRootFolder>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,4 +30,7 @@
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(SourceRootFolder)/**/*.cs" Exclude="$(SourceRootFolder)/obj/**/*" />
+  </ItemGroup>
 </Project>

--- a/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
+++ b/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
@@ -16,10 +16,12 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
     <EnableDefaultItems>false</EnableDefaultItems>
     <SourceRootFolder>../Alba</SourceRootFolder>
+    <RootNamespace>Alba</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
 
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />

--- a/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
+++ b/src/Alba.AspNetCore2/Alba.AspNetCore2.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.0" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.0.1" />

--- a/src/Alba.Testing.AspNetCore2/Alba.Testing.AspNetCore2.csproj
+++ b/src/Alba.Testing.AspNetCore2/Alba.Testing.AspNetCore2.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DebugType>portable</DebugType>
+    <AssemblyName>Alba.Testing.AspNetCore2</AssemblyName>
+    <PackageId>Alba.Testing.AspNetCore2</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <SourceRootFolder>../Alba.Testing/</SourceRootFolder>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Alba.AspNetCore2\Alba.AspNetCore2.csproj" />
+    <ProjectReference Include="..\WebApp\WebApp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="Shouldly" Version="2.8.2" />
+    <PackageReference Include="NSubstitute" Version="2.0.0-rc" />
+    <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.3.0" />
+    <PackageReference Include="StructureMap" Version="4.4.2" />
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SourceRootFolder)/**/*.cs" Exclude="$(SourceRootFolder)/obj/**/*" />
+  </ItemGroup>
+</Project>

--- a/src/Alba.Testing/Acceptance/assertions_against_authentication_response.cs
+++ b/src/Alba.Testing/Acceptance/assertions_against_authentication_response.cs
@@ -15,6 +15,7 @@ namespace Alba.Testing.Acceptance
         {
             using (var system = SystemUnderTest.ForStartup<Startup>())
             {
+                system.UseWindowsAuthentication();
                 await system.Scenario(_ =>
                 {
                     _.WithWindowsAuthentication();
@@ -29,11 +30,12 @@ namespace Alba.Testing.Acceptance
         [Fact]
         public async Task challenges_ntlm_negotiate_with_user()
         {
+            var user = new ClaimsPrincipal(new ClaimsIdentity(Enumerable.Empty<Claim>(), "Windows"));
             using (var system = SystemUnderTest.ForStartup<Startup>())
             {
+                system.UseWindowsAuthentication(user);
                 await system.Scenario(_ =>
                 {
-                    var user = new ClaimsPrincipal(new ClaimsIdentity(Enumerable.Empty<Claim>(), "Windows"));
                     _.WithWindowsAuthentication(user);
                     _.Get.Url("/auth/windowschallenge");
 

--- a/src/Alba.sln
+++ b/src/Alba.sln
@@ -8,7 +8,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.Testing", "Alba.Testin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApp", "WebApp\WebApp.csproj", "{52733A25-1E8D-4250-A9B5-D135EE6C1557}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.AspNetCore2", "Alba\Alba.AspNetCore2.csproj", "{2788ACBD-012D-4541-8B92-15BE87D6291C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.AspNetCore2", "Alba.AspNetCore2\Alba.AspNetCore2.csproj", "{74E8674B-0470-40E0-ADC7-98A10930126F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,10 +28,10 @@ Global
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52733A25-1E8D-4250-A9B5-D135EE6C1557}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2788ACBD-012D-4541-8B92-15BE87D6291C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74E8674B-0470-40E0-ADC7-98A10930126F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74E8674B-0470-40E0-ADC7-98A10930126F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74E8674B-0470-40E0-ADC7-98A10930126F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74E8674B-0470-40E0-ADC7-98A10930126F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Alba.sln
+++ b/src/Alba.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2008
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba", "Alba\Alba.csproj", "{81D9EFA5-F846-40F3-B36C-8E82111EDDF6}"
 EndProject
@@ -9,6 +9,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApp", "WebApp\WebApp.csproj", "{52733A25-1E8D-4250-A9B5-D135EE6C1557}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.AspNetCore2", "Alba.AspNetCore2\Alba.AspNetCore2.csproj", "{74E8674B-0470-40E0-ADC7-98A10930126F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Alba.Testing.AspNetCore2", "Alba.Testing.AspNetCore2\Alba.Testing.AspNetCore2.csproj", "{5BF67989-69FB-4A44-ADEC-E246A56271AC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,6 +34,10 @@ Global
 		{74E8674B-0470-40E0-ADC7-98A10930126F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74E8674B-0470-40E0-ADC7-98A10930126F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74E8674B-0470-40E0-ADC7-98A10930126F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BF67989-69FB-4A44-ADEC-E246A56271AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BF67989-69FB-4A44-ADEC-E246A56271AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BF67989-69FB-4A44-ADEC-E246A56271AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BF67989-69FB-4A44-ADEC-E246A56271AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Alba/Authentication/StubNtlmAuthenticationHandlerV2.cs
+++ b/src/Alba/Authentication/StubNtlmAuthenticationHandlerV2.cs
@@ -1,0 +1,56 @@
+﻿#if NETSTANDARD2_0
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.WebEncoders.Testing;
+using Microsoft.Net.Http.Headers;
+
+namespace Alba
+{
+    public class StubNtlmAuthenticationHandlerV2 : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        private readonly ClaimsPrincipal user;
+
+        public StubNtlmAuthenticationHandlerV2(ClaimsPrincipal user) 
+            : base(GetEmptyOptions(), new NullLoggerFactory(), new UrlTestEncoder(), new SystemClock()) {
+            this.user = user;
+        }
+
+        private static IOptionsMonitor<AuthenticationSchemeOptions> GetEmptyOptions() {
+            return new OptionsMonitor<AuthenticationSchemeOptions>(
+                new OptionsFactory<AuthenticationSchemeOptions>(
+                    Enumerable.Empty<IConfigureOptions<AuthenticationSchemeOptions>>(),
+                    Enumerable.Empty<IPostConfigureOptions<AuthenticationSchemeOptions>>()
+                ),
+                Enumerable.Empty<IOptionsChangeTokenSource<AuthenticationSchemeOptions>>(),
+                new OptionsCache<AuthenticationSchemeOptions>()
+            );
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() {
+            if (user == null) {
+                return Task.FromResult(AuthenticateResult.Fail("Nope"));
+            }
+
+            return Task.FromResult(
+                AuthenticateResult.Success(new AuthenticationTicket(user, "NTLM"))
+            );
+        }
+
+        protected override Task HandleChallengeAsync(AuthenticationProperties properties) {
+            Response.Headers[HeaderNames.WWWAuthenticate] = new StringValues(new[] {"NTLM", "Negotiate"});
+            Response.StatusCode = user == null ? 401 : 403;
+
+            return Task.CompletedTask;
+        }
+    }
+}
+#endif

--- a/src/Alba/SystemUnderTest.cs
+++ b/src/Alba/SystemUnderTest.cs
@@ -14,6 +14,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Newtonsoft.Json;
 
+#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+#endif
+
 namespace Alba
 {
     /// <summary>
@@ -24,6 +28,8 @@ namespace Alba
         private readonly WebHostBuilder _builder;
         private readonly IList<Action<IServiceCollection>> _registrations = new List<Action<IServiceCollection>>();
         private readonly IList<Action<IWebHostBuilder>> _configurations = new List<Action<IWebHostBuilder>>();
+
+        private Type startupType;
 
 
         /// <summary>
@@ -80,6 +86,8 @@ namespace Alba
             }
 
             Configure(x => x.UseStartup<T>());
+
+            startupType = typeof(T);
         }
 
         /// <summary>
@@ -130,6 +138,11 @@ namespace Alba
             {
                 JsonSerializerSettings = settings;
             }
+
+            #if NETSTANDARD2_0
+            var manager = host.Services.GetService<ApplicationPartManager>();
+            manager?.ApplicationParts.Add(new AssemblyPart(startupType.Assembly));
+            #endif
 
             return host;
         }

--- a/src/Alba/SystemUnderTestExtensions.cs
+++ b/src/Alba/SystemUnderTestExtensions.cs
@@ -1,7 +1,12 @@
 ﻿using System;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+
+#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Authentication;
+#endif
 
 namespace Alba
 {
@@ -55,6 +60,24 @@ namespace Alba
 
                 return scenario;
             }
+        }
+
+
+        public static SystemUnderTest UseWindowsAuthentication(this SystemUnderTest system, ClaimsPrincipal user = null) {
+#if NETSTANDARD2_0
+            system.Configure(c => {
+                c.ConfigureServices(s => {
+                    s.AddAuthentication(conf => {
+                        conf.DefaultAuthenticateScheme = "NTLM";
+                        conf.DefaultChallengeScheme = "Negotiate";
+                    })
+                        .AddScheme<AuthenticationSchemeOptions, StubNtlmAuthenticationHandlerV2>("NTLM", "NTLM", options =>  { })
+                        .AddScheme<AuthenticationSchemeOptions, StubNtlmAuthenticationHandlerV2>("Negotiate", "NTLM", options =>  { });
+                    s.AddSingleton(new StubNtlmAuthenticationHandlerV2(user));
+                });
+            });
+#endif
+            return system;
         }
     }
 }

--- a/src/WebApp/WebApp.csproj
+++ b/src/WebApp/WebApp.csproj
@@ -1,30 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebApp</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>WebApp</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;dotnet5.4;portable-net45+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0'">1.0.4</RuntimeFrameworkVersion>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.6;dotnet5.4;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
     <PackageReference Include="StructureMap.Microsoft.DependencyInjection" Version="1.3.0" />
   </ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp1.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="1.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
So, I'm fairly sure this doesn't pass muster as it is, but I figured I'd get your opinion on how to proceed from here.

After about four hours of furious debugging, I was able to figure out that the tests didn't pass because for whatever reason, when running under the test harness, the Application Part discovery for the WebApp wasn't finding controllers at all. 

This is only an issue within Alba's own test suite, because I have a packaged version that I've been using to TDD an API project for a couple of months now, and it works as expected. In any case, grabbing the type of the startup class and registering its assembly as an Application Part fixed all but two of the tests, so I'm not feeling too bad about this. The relevant changes are all in SystemUnderTest.cs.

The remaining two test failures have to do with testing Windows authentication. The entire authentication stack has changed for ASP.NET Core 2.0, so I cobbled together something that makes the tests pass. There are two problems here, though:

First, the API has to be different, as configuring this authentication mechanism has to happen as part of the Configure step, not within the Scenario call. I haven't resolved this in any meaningful way yet, because it's an API compatibility issue I don't feel qualified to resolve.

Second, I have no idea if the authentication handler I wrote actually does the right thing for the tests to be meaningful. 