### PR TITLE
Switch HttpContext.Items to ItemsDictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ src/.idea
 doc-target
 stresults.htm
 project.lock.json
+*.DS_Store

--- a/src/Alba/Stubs/StubHttpContext.cs
+++ b/src/Alba/Stubs/StubHttpContext.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Authentication;
+using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.AspNetCore.Http.Features;
 
 namespace Alba.Stubs
@@ -58,7 +59,7 @@ namespace Alba.Stubs
         public override ClaimsPrincipal User { get; set; } = new ClaimsPrincipal();
 
 
-        public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+        public override IDictionary<object, object> Items { get; set; } = new ItemsDictionary();
 
         public sealed override IServiceProvider RequestServices { get; set; }
 


### PR DESCRIPTION
* Some libraries depend on the behavior of HttpContext.Items to not
  throw which was causing errors in tests.

GH: #47