### PR TITLE
headers: add .SingleValueShouldMatch(regex) assertion

### DIFF
--- a/src/Alba.Testing/Assertions/HeaderMatchAssertionTests.cs
+++ b/src/Alba.Testing/Assertions/HeaderMatchAssertionTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Text.RegularExpressions;
+using Alba.Assertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Alba.Testing.Assertions
+{
+    public class HeaderMatchAssertionTests
+    {
+        private readonly HeaderMatchAssertion _assertion;
+
+        public HeaderMatchAssertionTests()
+        {
+            _assertion = new HeaderMatchAssertion("foo", new Regex("^b.?r$"));
+        }
+
+        [Fact]
+        public void happy_path()
+        {
+            AssertionRunner.Run(_assertion, x => x.Response.Headers["foo"] = "bar")
+                .AssertAll();
+        }
+
+        [Fact]
+        public void sad_path_no_values()
+        {
+            AssertionRunner.Run(_assertion, e => { })
+                .SingleMessageShouldBe("Expected a single header value of 'foo' matching '^b.?r$', but no values were found on the response");
+        }
+
+        [Fact]
+        public void sad_path_wrong_value()
+        {
+            AssertionRunner.Run(_assertion, x => x.Response.Headers["foo"] = "baz")
+                .SingleMessageShouldBe("Expected a single header value of 'foo' matching '^b.?r$', but the actual value was 'baz'");
+        }
+
+        [Fact]
+        public void sad_path_too_many_values()
+        {
+            AssertionRunner.Run(_assertion, x =>
+                {
+                    x.Response.Headers.Append("foo", "baz");
+                    x.Response.Headers.Append("foo", "bar");
+                })
+                .SingleMessageShouldBe("Expected a single header value of 'foo' matching '^b.?r$', but the actual values were 'baz', 'bar'");
+        }
+    }
+}

--- a/src/Alba.Testing/Samples/Headers.cs
+++ b/src/Alba.Testing/Samples/Headers.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Alba.Testing.Samples
 {
@@ -52,6 +53,9 @@ namespace Alba.Testing.Samples
 
                 // Assert that the header has the given values
                 _.Header("www-authenticate").ShouldHaveValues("NTLM", "Negotiate");
+
+                // Assert that the header matches a regular expression
+                _.Header("location").SingleValueShouldMatch(new Regex(@"^/items/\d*$"));
 
                 // Check the content-type header
                 _.ContentTypeShouldBe("text/json");

--- a/src/Alba/Assertions/HeaderMatchAssertion.cs
+++ b/src/Alba/Assertions/HeaderMatchAssertion.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Baseline;
+
+namespace Alba.Assertions
+{
+    public class HeaderMatchAssertion : IScenarioAssertion
+    {
+        private readonly string _headerKey;
+        private readonly Regex _regex;
+
+        public HeaderMatchAssertion(string headerKey, Regex regex)
+        {
+            _headerKey = headerKey;
+            _regex = regex;
+        }
+
+        public void Assert(Scenario scenario, ScenarioAssertionException ex)
+        {
+            var values = scenario.Context.Response.Headers[_headerKey];
+
+            switch (values.Count)
+            {
+                case 0:
+                    ex.Add($"Expected a single header value of '{_headerKey}' matching '{_regex}', but no values were found on the response");
+                    break;
+
+                case 1:
+                    var actual = values.Single();
+                    if (_regex.IsMatch(actual) == false)
+                    {
+                        ex.Add($"Expected a single header value of '{_headerKey}' matching '{_regex}', but the actual value was '{actual}'");
+                    }
+                    break;
+
+                default:
+                    var valueText = values.Select(x => "'" + x + "'").Join(", ");
+                    ex.Add($"Expected a single header value of '{_headerKey}' matching '{_regex}', but the actual values were {valueText}");
+                    break;
+            }
+        }
+    }
+}

--- a/src/Alba/HeaderExpectations.cs
+++ b/src/Alba/HeaderExpectations.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Alba.Assertions;
 
 namespace Alba
@@ -33,6 +34,27 @@ namespace Alba
         {
             _parent.AssertThat(new HasSingleHeaderValueAssertion(_headerKey));
             return this;
+        }
+
+        /// <summary>
+        /// Asserts that there is a single header value matching 'expected'
+        /// regular expression in the Http response
+        /// </summary>
+        /// <returns></returns>
+        public HeaderExpectations SingleValueShouldMatch(Regex regex)
+        {
+            _parent.AssertThat(new HeaderMatchAssertion(_headerKey, regex));
+            return this;
+        }
+
+        /// <summary>
+        /// Asserts that there is a single header value matching 'expected'
+        /// regular expression in the Http response
+        /// </summary>
+        /// <returns></returns>
+        public HeaderExpectations SingleValueShouldMatch(string regex)
+        {
+            return SingleValueShouldMatch(new Regex(regex));
         }
 
         /// <summary>


### PR DESCRIPTION
When testing an api, I am often returning the `location` header with a url which might not be guessable (e.g. `/someresource/id/some-guid-here`), so here is a pullrequest to add support for matching a header against a regex:

```csharp
_.Header("location").SingleValueShouldMatch(new Regex(@"^/items/\d*$"));
// or
_.Header("location").SingleValueShouldMatch(@"^/items/\d*$");
````