### PR TITLE
Pick serializer settings properly

### DIFF
--- a/src/Alba/Alba.csproj
+++ b/src/Alba/Alba.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Baseline" Version="1.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
   </ItemGroup>
@@ -26,16 +25,17 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-      <PackageReference Include="Microsoft.AspNetCore.All" />
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-      <PackageReference Include="Microsoft.AspNetCore.All" />
-      <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.*" />
   </ItemGroup>
 
 </Project>

--- a/src/Alba/SystemUnderTest.cs
+++ b/src/Alba/SystemUnderTest.cs
@@ -11,10 +11,12 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace Alba
@@ -48,7 +50,8 @@ namespace Alba
 
 
 
-            var settings = host.Services.GetService<JsonSerializerSettings>();
+            var options = host.Services.GetService<IOptions<MvcNewtonsoftJsonOptions>>()?.Value;
+            var settings = options?.SerializerSettings;
             if (settings != null) JsonSerializerSettings = settings;
 
             var manager = host.Services.GetService<ApplicationPartManager>();


### PR DESCRIPTION
According to the ASP.NET source code, `JsonSerializerSettings` is not registered as a service, but into `MvcNewtonsoftJsonOptions`.

Check for example how `NewtonsoftJsonHelper` makes use of that: https://source.dot.net/#Microsoft.AspNetCore.Mvc.NewtonsoftJson/NewtonsoftJsonHelper.cs
