### PR TITLE
Handle non-HMAC signing keys

### DIFF
--- a/src/Alba/Security/JwtSecurityStub.cs
+++ b/src/Alba/Security/JwtSecurityStub.cs
@@ -115,7 +115,8 @@ namespace Alba.Security
                 NameClaimType = original.NameClaimType,
                 NameClaimTypeRetriever = original.NameClaimTypeRetriever,
                 RoleClaimType = original.RoleClaimType,
-                RoleClaimTypeRetriever = original.RoleClaimTypeRetriever
+                RoleClaimTypeRetriever = original.RoleClaimTypeRetriever,
+                ValidAlgorithms = original.ValidAlgorithms
             };
             
             options.Authority = null;


### PR DESCRIPTION
Since we currently [strip out](https://github.com/JasperFx/alba/blob/aff5c52fb5a8541fa72886724156488063a64710/src/Alba/Security/JwtSecurityStub.cs#L109) from original `TokenValidationParameters.ValidAlgorithms` the code [defaults](https://github.com/JasperFx/alba/blob/aff5c52fb5a8541fa72886724156488063a64710/src/Alba/Security/JwtSecurityStub.cs#L71) to HMAC and will throw as soon as we try to use JWT token with this signing key.

This PR makes sure that we propagate the original  `TokenValidationParameters.ValidAlgorithms` so that singing keys based on non-HMAC algorithms do not throw.