### PR TITLE
Created an Assertion for StatusCodeShouldBeSuccess

### DIFF
--- a/src/Alba.Testing/Acceptance/asserting_against_status_code.cs
+++ b/src/Alba.Testing/Acceptance/asserting_against_status_code.cs
@@ -69,5 +69,53 @@ namespace Alba.Testing.Acceptance
             ex.Message.ShouldContain("Expected status code 200, but was 500");
             ex.Message.ShouldContain("the error text");
         }
+
+        [Fact]
+        public async Task using_scenario_with_StatusCodeShouldBeSuccess_happy_path()
+        {
+            router.Handlers["/one"] = c =>
+            {
+                c.Response.StatusCode = 204;
+                c.Response.ContentType("text/plain");
+                c.Response.Write("Some text");
+
+                return Task.CompletedTask;
+            };
+
+            var ex = await Exception<ScenarioAssertionException>.ShouldBeThrownBy(() =>
+            {
+                return host.Scenario(x =>
+                {
+                    x.Get.Url("/one");
+                    x.StatusCodeShouldBeSuccess();
+                });
+            });
+
+        }
+
+        [Fact]
+        public async Task using_scenario_with_StatusCodeShouldBeSuccess_sad_path()
+        {
+            router.Handlers["/one"] = c =>
+            {
+                c.Response.StatusCode = 500;
+                c.Response.ContentType("text/plain");
+                c.Response.Write("Some text");
+
+                return Task.CompletedTask;
+            };
+
+            var ex = await Exception<ScenarioAssertionException>.ShouldBeThrownBy(() =>
+            {
+                return host.Scenario(x =>
+                {
+                    x.Get.Url("/one");
+                    x.StatusCodeShouldBeSuccess();
+                });
+            });
+
+            ex.Message.ShouldContain("Expected status code 200, but was 500");
+        }
+
     }
 }

--- a/src/Alba.Testing/Assertions/StatusCodeSuccessAssertionTests.cs
+++ b/src/Alba.Testing/Assertions/StatusCodeSuccessAssertionTests.cs
@@ -1,0 +1,69 @@
+﻿using Alba.Assertions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Alba.Testing.Assertions
+{
+    public class StatusCodeSuccessAssertionTests
+    {
+        [Theory]
+        [ClassData(typeof(SuccessStatusCodes))]
+        public void HappyPath(int statusCode)
+        {
+            var assertion = new StatusCodeSuccessAssertion();
+
+            AssertionRunner.Run(assertion, _ => _.StatusCode(statusCode))
+                .AssertAll();
+        }
+
+        [Theory]
+        [ClassData(typeof(FailureStatusCodes))]
+        public void SadPath(int statusCode)
+        {
+            var assertion = new StatusCodeSuccessAssertion();
+
+            AssertionRunner.Run(assertion, _ => _.StatusCode(statusCode))
+                .SingleMessageShouldBe($"Expected a status code between 200 and 299, but was {statusCode}");
+        }
+    }
+
+   
+        
+}
+
+public class SuccessStatusCodes : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        foreach (var code in Enumerable.Range(200, 99))
+        {
+            yield return new object[] { code };
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    
+}
+
+public class FailureStatusCodes : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        foreach (var code in Enumerable.Range(100, 99))
+        {
+            yield return new object[] { code };
+        }
+        foreach (var code in Enumerable.Range(300, 200))
+        {
+            yield return new object[] { code };
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+}

--- a/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
+++ b/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Alba.Assertions
+{
+    public class StatusCodeSuccessAssertion : IScenarioAssertion
+    {
+        public void Assert(Scenario scenario, HttpContext context, ScenarioAssertionException ex)
+        {
+            var statusCode = context.Response.StatusCode;
+            if(statusCode < 200 || statusCode >= 300)
+            {
+                ex.Add($"Expected a status code between 200 and 299, but was {statusCode}");
+                ex.ReadBody(context);
+            }
+        }
+    }
+}

--- a/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
+++ b/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
@@ -1,22 +1,14 @@
-﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Alba.Assertions;
 
-namespace Alba.Assertions
+public sealed class StatusCodeSuccessAssertion : IScenarioAssertion
 {
-    public class StatusCodeSuccessAssertion : IScenarioAssertion
+    public void Assert(Scenario scenario, AssertionContext context)
     {
-        public void Assert(Scenario scenario, HttpContext context, ScenarioAssertionException ex)
+        var statusCode = context.HttpContext.Response.StatusCode;
+        if(statusCode < 200 || statusCode >= 300)
         {
-            var statusCode = context.Response.StatusCode;
-            if(statusCode < 200 || statusCode >= 300)
-            {
-                ex.Add($"Expected a status code between 200 and 299, but was {statusCode}");
-                ex.ReadBody(context);
-            }
+            context.AddFailure($"Expected a status code between 200 and 299, but was {statusCode}");
+            context.ReadBodyAsString();
         }
     }
 }

--- a/src/Alba/ScenarioExpectationsExtensions.cs
+++ b/src/Alba/ScenarioExpectationsExtensions.cs
@@ -50,17 +50,27 @@ public static class ScenarioExpectationsExtensions
         return scenario.StatusCodeShouldBe(HttpStatusCode.OK);
     }
 
-    /// <summary>
-    /// Assert that the content-type header value of the Http response
-    /// matches the expected value
-    /// </summary>
-    /// <param name="scenario"></param>
-    /// <param name="mimeType"></param>
-    /// <returns></returns>
-    public static Scenario ContentTypeShouldBe(this Scenario scenario, MimeType mimeType)
-    {
-        return scenario.ContentTypeShouldBe(mimeType.Value);
-    }
+        /// <summary>
+        /// Assert tha the Http Status Code is between 200 and 299
+        /// </summary>
+        /// <param name="scenario"></param>
+        /// <returns></returns>
+        public static Scenario StatusCodeShouldBeSuccess(this Scenario scenario)
+        {
+            return scenario.AssertThat(new StatusCodeSuccessAssertion());
+        }
+
+        /// <summary>
+        /// Assert that the content-type header value of the Http response
+        /// matches the expected value
+        /// </summary>
+        /// <param name="scenario"></param>
+        /// <param name="mimeType"></param>
+        /// <returns></returns>
+        public static Scenario ContentTypeShouldBe(this Scenario scenario, MimeType mimeType)
+        {
+            return scenario.ContentTypeShouldBe(mimeType.Value);
+        }
 
 
     /// <summary>

--- a/src/Alba/ScenarioExpectationsExtensions.cs
+++ b/src/Alba/ScenarioExpectationsExtensions.cs
@@ -1,11 +1,12 @@
 using System.Net;
 using Alba.Assertions;
- 
+
 namespace Alba;
 
 public static class ScenarioExpectationsExtensions
 {
     #region sample_ContentShouldContain
+
     /// <summary>
     /// Assert that the Http response contains the designated text
     /// </summary>
@@ -16,6 +17,7 @@ public static class ScenarioExpectationsExtensions
     {
         return scenario.AssertThat(new BodyContainsAssertion(text));
     }
+
     #endregion
 
     /// <summary>
@@ -50,27 +52,27 @@ public static class ScenarioExpectationsExtensions
         return scenario.StatusCodeShouldBe(HttpStatusCode.OK);
     }
 
-        /// <summary>
-        /// Assert tha the Http Status Code is between 200 and 299
-        /// </summary>
-        /// <param name="scenario"></param>
-        /// <returns></returns>
-        public static Scenario StatusCodeShouldBeSuccess(this Scenario scenario)
-        {
-            return scenario.AssertThat(new StatusCodeSuccessAssertion());
-        }
+    /// <summary>
+    /// Assert that the Http Status Code is between 200 and 299
+    /// </summary>
+    /// <param name="scenario"></param>
+    /// <returns></returns>
+    public static Scenario StatusCodeShouldBeSuccess(this Scenario scenario)
+    {
+        return scenario.AssertThat(new StatusCodeSuccessAssertion());
+    }
 
-        /// <summary>
-        /// Assert that the content-type header value of the Http response
-        /// matches the expected value
-        /// </summary>
-        /// <param name="scenario"></param>
-        /// <param name="mimeType"></param>
-        /// <returns></returns>
-        public static Scenario ContentTypeShouldBe(this Scenario scenario, MimeType mimeType)
-        {
-            return scenario.ContentTypeShouldBe(mimeType.Value);
-        }
+    /// <summary>
+    /// Assert that the content-type header value of the Http response
+    /// matches the expected value
+    /// </summary>
+    /// <param name="scenario"></param>
+    /// <param name="mimeType"></param>
+    /// <returns></returns>
+    public static Scenario ContentTypeShouldBe(this Scenario scenario, MimeType mimeType)
+    {
+        return scenario.ContentTypeShouldBe(mimeType.Value);
+    }
 
 
     /// <summary>


### PR DESCRIPTION
Unsolicited contribution - but I often want to be a little fuzzy on asserting status codes (a 200 is as good as a 201, or a 204, for example). I added an assertion for `api.StatusCodeShouldBeSuccess()` that will pass if the status code is in the proper range of "success". 

Since Alba's default behavior is to fail if there is no assertion on the status code and it returns *anything* but a 200, this seems like a good accommodation. (I'd prefer the default was this, but I get why others wouldn't, and don't want a breaking change anyhow).

I've had this as my own custom assertion for a while, and don't mind keeping it that way, but if it is helpful, take it.