### PR TITLE
Fixed the StatusCodeSuccessAssertion

### DIFF
--- a/src/Alba.Testing/Acceptance/asserting_against_status_code.cs
+++ b/src/Alba.Testing/Acceptance/asserting_against_status_code.cs
@@ -5,6 +5,7 @@ namespace Alba.Testing.Acceptance
 {
     public class asserting_against_status_code : ScenarioContext
     {
+
         [Fact]
         public Task using_scenario_with_StatusCodeShouldBe_happy_path()
         {
@@ -69,7 +70,7 @@ namespace Alba.Testing.Acceptance
         }
 
         [Fact]
-        public async Task using_scenario_with_StatusCodeShouldBeSuccess_happy_path()
+        public Task using_scenario_with_StatusCodeShouldBeSuccess_happy_path()
         {
             router.Handlers["/one"] = c =>
             {
@@ -80,14 +81,13 @@ namespace Alba.Testing.Acceptance
                 return Task.CompletedTask;
             };
 
-            var ex = await Exception<ScenarioAssertionException>.ShouldBeThrownBy(() =>
-            {
+         
                 return host.Scenario(x =>
                 {
                     x.Get.Url("/one");
                     x.StatusCodeShouldBeSuccess();
                 });
-            });
+            
 
         }
 
@@ -112,7 +112,7 @@ namespace Alba.Testing.Acceptance
                 });
             });
 
-            ex.Message.ShouldContain("Expected status code 200, but was 500");
+            ex.Message.ShouldContain("Expected a status code between 200 and 299, but was 500");
         }
 
     }

--- a/src/Alba.Testing/Samples/ContractTestWithAlba.cs
+++ b/src/Alba.Testing/Samples/ContractTestWithAlba.cs
@@ -111,6 +111,7 @@ public class WebAppFixture : IAsyncLifetime
             {
                 _.Get.Url("/fake/okay");
                 _.StatusCodeShouldBeOk();
+                _.StatusCodeShouldBeSuccess();
             });
         }
     }

--- a/src/Alba/Assertions/IStatusCodeAssertion.cs
+++ b/src/Alba/Assertions/IStatusCodeAssertion.cs
@@ -1,0 +1,6 @@
+namespace Alba.Assertions;
+
+public interface IStatusCodeAssertion
+{
+  
+}

--- a/src/Alba/Assertions/StatusCodeAssertion.cs
+++ b/src/Alba/Assertions/StatusCodeAssertion.cs
@@ -1,7 +1,7 @@
 namespace Alba.Assertions;
 
 #region sample_StatusCodeAssertion
-internal sealed class StatusCodeAssertion : IScenarioAssertion
+internal sealed class StatusCodeAssertion : IScenarioAssertion, IStatusCodeAssertion
 {
     public int Expected { get; set; }
 

--- a/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
+++ b/src/Alba/Assertions/StatusCodeSuccessAssertion.cs
@@ -1,10 +1,11 @@
 ﻿namespace Alba.Assertions;
 
-public sealed class StatusCodeSuccessAssertion : IScenarioAssertion
+public sealed class StatusCodeSuccessAssertion : IScenarioAssertion, IStatusCodeAssertion
 {
     public void Assert(Scenario scenario, AssertionContext context)
     {
         var statusCode = context.HttpContext.Response.StatusCode;
+       
         if(statusCode < 200 || statusCode >= 300)
         {
             context.AddFailure($"Expected a status code between 200 and 299, but was {statusCode}");

--- a/src/Alba/Scenario.cs
+++ b/src/Alba/Scenario.cs
@@ -264,6 +264,8 @@ public class Scenario : IUrlExpression
 
     internal void RunAssertions(HttpContext context)
     {
+       _ignoreStatusCode = _ignoreStatusCode || _assertions.Any(x => x is IStatusCodeAssertion);
+       
         var assertionContext = new AssertionContext(context, _assertionRecords);
         if (!_ignoreStatusCode)
         {

--- a/src/Alba/ScenarioExpectationsExtensions.cs
+++ b/src/Alba/ScenarioExpectationsExtensions.cs
@@ -58,7 +58,8 @@ public static class ScenarioExpectationsExtensions
     /// <param name="scenario"></param>
     /// <returns></returns>
     public static Scenario StatusCodeShouldBeSuccess(this Scenario scenario)
-    {
+    {   
+        //scenario.IgnoreStatusCode();
         return scenario.AssertThat(new StatusCodeSuccessAssertion());
     }
 


### PR DESCRIPTION
Ok - not sure this is the right approach, but I sort of messed up the `StatusCodeShouldBeSuccess()` Assertion last year.

I actually noticed this when recording a video with @jeremydmiller. ;(

I feel like I made too big of a change here, and don't mind rejection or feedback.

The issue is the StatusCodeShouldBeSuccess() collided with the default (StatusCodeShouldBeOk). 

Since StatusCodes are pretty binary - you wouldn't have multiple checks for different status codes in the same scenario, the `Scenario.cs` has a `IgnoreStatusCode()` you can use.  so in order for the `StatusCodeShouldBeSuccess()` to work, you'd have to do something like:

```cs
 var response = await M.Host.Scenario(api =>
        {
             api.Post.Json(request).ToUrl("/work-to-be-done");
             api.IgnoreStatusCode(); // <-- add this.
             api.StatusCodeShouldBeSuccess();    
        });
```

That seems *weird* to me. 

What I propose, meekly, with this PR is (egads) a "Marker Interface" for any Assertion that deals with Status Codes. (`IStatusCodeAssertion`). 

In the `Scenario.cs`'s `RunAssertions`, you set `_ignoreStatusCode` to true (if it isn't already) if there are any `_assertions` that implement that interface.

Now, the above can be written as:

```cs
 var response = await M.Host.Scenario(api =>
        {
             api.Post.Json(request).ToUrl("/work-to-be-done");
             // api.IgnoreStatusCode(); // <-- remove this
             api.StatusCodeShouldBeSuccess();    
        });
```
I *considered* throwing something if there are more than one assertion that is `IStatusCodeAssertion`, but that feels too heavy handed.

If this is accepted (and I can't help but think there might be a better way, or someone will see a problem with this), I'd be willing to update the documentation at https://jasperfx.github.io/alba/scenarios/assertions.html. 

Thanks, and sorry?
