### PR TITLE
Remove redundant type constraint T: class on IUrlEpxression.Json method

### DIFF
--- a/src/Alba/IUrlExpression.cs
+++ b/src/Alba/IUrlExpression.cs
@@ -34,7 +34,7 @@ public interface IUrlExpression
     /// <param name="jsonStyle"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    SendExpression Json<T>(T input, JsonStyle? jsonStyle = null) where T : class;
+    SendExpression Json<T>(T input, JsonStyle? jsonStyle = null);
 
 
     /// <summary>


### PR DESCRIPTION
The type constraint "where T: class" on IUrlEpxression.Json makes it impossible to use structs in test scenarios. Given that structs are serializable by default, I don't see the benefit of having this constraint in place.