### PR TITLE
Update MockAuthenticationHandler to support SignOut

### DIFF
--- a/src/Alba/Security/AuthenticationStub.cs
+++ b/src/Alba/Security/AuthenticationStub.cs
@@ -78,7 +78,7 @@ public sealed class AuthenticationStub : AuthenticationExtensionBase, IAlbaExten
             return base.GetSchemeAsync(name);
         }
 
-        private sealed class MockAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+        private sealed class MockAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>, IAuthenticationSignOutHandler
         {
             private readonly AuthenticationStub _authenticationSchemaStub;
 
@@ -93,6 +93,11 @@ public sealed class AuthenticationStub : AuthenticationExtensionBase, IAlbaExten
                 var principal = _authenticationSchemaStub.BuildPrincipal(Context);
                 var ticket = new AuthenticationTicket(principal, TestSchemaName);
                 return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+
+            public Task SignOutAsync(AuthenticationProperties? properties)
+            {
+                return Task.CompletedTask;
             }
         }
     }


### PR DESCRIPTION
Updated the mock handler to support signout flow. This is called by ASP.net if controller code calls signout.
It doesn't do anything but at least it won't throw _"The authentication handler registered for scheme '<scheme>' is 'MockAuthenticationHandler' which cannot be used for SignOutAsync"_.