### PR TITLE
Enable JasperFxEnvironment.AutoStartHost automatically

### DIFF
--- a/src/Alba.Testing/Acceptance/host_auto_start.cs
+++ b/src/Alba.Testing/Acceptance/host_auto_start.cs
@@ -1,0 +1,15 @@
+﻿using JasperFx.CommandLine;
+using Shouldly;
+
+namespace Alba.Testing.Acceptance;
+
+public class host_auto_start
+{
+    [Fact]
+    public async Task should_enable_auto_start_host()
+    {
+        await using var host = await AlbaHost.For<Program>();
+
+        JasperFxEnvironment.AutoStartHost.ShouldBe(true);
+    }
+}

--- a/src/Alba.Testing/Acceptance/host_cmd_arguments.cs
+++ b/src/Alba.Testing/Acceptance/host_cmd_arguments.cs
@@ -1,4 +1,4 @@
-﻿using Shouldly;
+using Shouldly;
 
 namespace Alba.Testing.Acceptance;
 

--- a/src/Alba.Testing/Acceptance/host_cmd_arguments.cs
+++ b/src/Alba.Testing/Acceptance/host_cmd_arguments.cs
@@ -17,7 +17,20 @@ public class host_cmd_arguments
         await using var host = await AlbaHost.For<Program>();
 
         var args = await GetCmdArgumentsAsync(host);
-        args.Keys.ShouldBe(DefaultParameters);
+        args.Keys.ShouldBe(DefaultParameters, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task should_use_extra_cmd_parameters_when_running_without_RunJasperFxCommand()
+    {
+        await using var host = await AlbaHost.For<Program>(x => x
+            .UseSetting("extra1", "value")
+            .UseSetting("extra2", null));
+
+        var args = await GetCmdArgumentsAsync(host);
+        args.Keys.ShouldBe(
+            DefaultParameters.Concat(["--extra1", "--extra2"]),
+            ignoreOrder: true);
     }
 
     [Fact]
@@ -26,7 +39,20 @@ public class host_cmd_arguments
         await using var host = await AlbaHost.For<MinimalApiWithOakton.Program>();
 
         var args = await GetCmdArgumentsAsync(host);
-        args.Keys.ShouldBe(DefaultParameters);
+        args.Keys.ShouldBe(DefaultParameters, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task should_use_extra_cmd_parameters_when_running_with_RunJasperFxCommand()
+    {
+        await using var host = await AlbaHost.For<MinimalApiWithOakton.Program>(x => x
+            .UseSetting("extra1", "value")
+            .UseSetting("extra2", null));
+
+        var args = await GetCmdArgumentsAsync(host);
+        args.Keys.ShouldBe(
+            DefaultParameters.Concat(["--extra1", "--extra2"]),
+            ignoreOrder: true);
     }
 
     private static async Task<Dictionary<string, string>> GetCmdArgumentsAsync(IAlbaHost host)

--- a/src/Alba.Testing/Acceptance/host_stop_usage.cs
+++ b/src/Alba.Testing/Acceptance/host_stop_usage.cs
@@ -1,5 +1,4 @@
-﻿using JasperFx.CommandLine;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Shouldly;
 using WebApp;
@@ -11,7 +10,6 @@ public class host_stop_usage
     [Fact]
     public async Task stop_for_hosted_service_is_called_for_minimal_api()
     {
-        JasperFxEnvironment.AutoStartHost = true;
         await using var host = await AlbaHost.For<Program>(x =>
         {
             x.ConfigureServices(services =>
@@ -28,7 +26,6 @@ public class host_stop_usage
     [Fact]
     public async Task stop_for_hosted_service_is_called_on_host_disposal_for_minimal_api()
     {
-        JasperFxEnvironment.AutoStartHost = true;
         var host = await AlbaHost.For<Program>(x =>
         {
             x.ConfigureServices(services =>

--- a/src/Alba.Testing/Acceptance/web_application_factory_usage.cs
+++ b/src/Alba.Testing/Acceptance/web_application_factory_usage.cs
@@ -1,4 +1,3 @@
-using JasperFx.CommandLine;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 
@@ -73,8 +72,6 @@ namespace Alba.Testing.Acceptance
         [Fact]
         public async Task using_with_oakton_as_runner()
         {
-            // This is required. Sad trombone.
-            JasperFxEnvironment.AutoStartHost = true;
             await using var host = await AlbaHost.For<MinimalApiWithOakton.Program>(x =>
             {
                 x.ConfigureServices((context, services) =>

--- a/src/Alba.Testing/MimimalApi/end_to_end_with_json_serialization.cs
+++ b/src/Alba.Testing/MimimalApi/end_to_end_with_json_serialization.cs
@@ -1,6 +1,5 @@
 using Lamar;
 using MinimalApiWithOakton;
-using JasperFx.CommandLine;
 using Shouldly;
 
 namespace Alba.Testing.MimimalApi;
@@ -17,7 +16,6 @@ public class end_to_end_with_json_serialization : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        JasperFxEnvironment.AutoStartHost = true;
         _host = await AlbaHost.For<MinimalApiWithOakton.Program>();
 
         var container = (IContainer)_host.Services;

--- a/src/Alba/AlbaHost.cs
+++ b/src/Alba/AlbaHost.cs
@@ -321,6 +321,7 @@ public class AlbaHost : IAlbaHost
     public static async Task<IAlbaHost> For<TEntryPoint>(Action<IWebHostBuilder> configuration,
         params IAlbaExtension[] extensions) where TEntryPoint : class
     {
+        JasperFxEnvironmentAutoStartHost.Enable();
         var factory = new AlbaWebApplicationFactory<TEntryPoint>(configuration, extensions);
 
         var host = new AlbaHost(factory, extensions);

--- a/src/Alba/JasperFxEnvironmentAutoStartHost.cs
+++ b/src/Alba/JasperFxEnvironmentAutoStartHost.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Alba;
+
+internal static class JasperFxEnvironmentAutoStartHost
+{
+    private static string JasperFxDllPath =>
+        Path.Combine(AppContext.BaseDirectory, "JasperFx.dll");
+
+    private static readonly Lazy<Action> AutoStartHostEnabler = new(() =>
+    {
+        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(JasperFxDllPath);
+        var environment = assembly.GetType("JasperFx.CommandLine.JasperFxEnvironment");
+        var autoStartHost = environment?.GetProperty(
+            "AutoStartHost",
+            BindingFlags.Static | BindingFlags.Public);
+
+        return () => autoStartHost?.SetValue(null, true);
+    });
+
+    public static void Enable()
+    {
+        if (AutoStartHostEnabler.IsValueCreated)
+        {
+            AutoStartHostEnabler.Value.Invoke();
+            return;
+        }
+
+        if (File.Exists(JasperFxDllPath))
+            AutoStartHostEnabler.Value.Invoke();
+    }
+}


### PR DESCRIPTION
This PR enables `JasperFxEnvironment.AutoStart` automatically to avoid `System.InvalidOperationException : The server has not been started or no web application was configured.` when the tested app uses `RunJasperFxCommands`.

Setting `JasperFxEnvironment.AutoStart` manually as a required workaround is not easily discoverable.